### PR TITLE
Handle trailing comma on last item.

### DIFF
--- a/h/uCurses.h
+++ b/h/uCurses.h
@@ -437,6 +437,7 @@ void json_error(char *s);
 void json_new_state_struct(size_t struct_size, uint32_t struct_type);
 void json_state_value(void);
 void json_state_key(void);
+void json_state_r_brace(void);
 void j_pop(void);
 void strip_quotes(uint16_t len);
 int json_create_ui(char *path, fp_finder_t fp);

--- a/src/json.c
+++ b/src/json.c
@@ -357,7 +357,7 @@ static void populate_parent(void)
 
 // -----------------------------------------------------------------------
 
-static void json_state_r_brace(void)
+void json_state_r_brace(void)
 {
     uint16_t has_comma = 0;
     uint16_t end = strlen(json_token) - 1;

--- a/src/json_key.c
+++ b/src/json_key.c
@@ -484,8 +484,17 @@ static const switch_t object_types[] =
 void json_state_key(void)
 {
     int f;
+    size_t len;
 
-    size_t len = strlen(json_token);
+    if (json_token[0] == '}')
+    {
+        // user put in a trailing comma, hence the unexpected right brace
+        // so just handle this as a right brace...
+        json_state_r_brace();
+        return;
+    }
+
+    len = strlen(json_token);
 
     if((json_token[0]       != '"') ||
        (json_token[len - 1] != '"'))


### PR DESCRIPTION
Not valid json, but very common thing to support.
Confirmed that it works.